### PR TITLE
Add docker image info to GitHub Actions log

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
           docker build .
           -t ${{steps.info.outputs.tag}}
           --build-arg VS_VERSION=${{matrix.msvc}}
+      - name: Report image details
+        run: >
+          docker image history
+          --no-trunc
+          --format "table {{.Size}}\t{{.CreatedBy}}"
+          ${{steps.info.outputs.tag}}
       - name: Login to registry
         if: github.ref == 'refs/heads/main'
         run: >


### PR DESCRIPTION
Will help us understand where the images size comes from.