### PR TITLE
Fix exit code

### DIFF
--- a/vs-helpers/init.ps1
+++ b/vs-helpers/init.ps1
@@ -32,3 +32,5 @@ cmd /c """$vcvars"" $architecture & set" | foreach {
 Write-Host 'Done'
 Write-Host '------------------------------------------------------------'
 Invoke-Expression "$args"
+
+exit $LastExitCode


### PR DESCRIPTION
This allows propagation of the exit code from `Invoke-Expression` to the docker container. This allows the exit code to be reflected in dockers exit code.