### PR TITLE
Add x86/x64 VC tools component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN C:\\Temp\\install-wrapper.cmd C:\\Temp\\vsbuildtools.exe \
       --channelUri C:\\Temp\\vschannel.chman \
       --installChannelUri C:\\Temp\\vschannel.chman \
       --add Microsoft.VisualStudio.Workload.VCTools \
+      --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
       --add Microsoft.VisualStudio.Component.VC.ATL && \
     rmdir /s /q C:\\Temp && \
     del /s /f /q %TEMP%


### PR DESCRIPTION
The x86/x64 tools are installed by default for Visual Studio 2017 but are not for Visual Studio 2019.