### PR TITLE
Add debug option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG CMAKE_VERSION="3.18.2"
 ARG SDK_VERSION="17763"
 
 # set environment variables to defaults
-ENV VS_VERSION=${VS_VERSION} \
+ENV DEBUG="0" \
+    VS_VERSION=${VS_VERSION} \
     VS_ARCH="amd64"
 
 # set default shell

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -6,7 +6,7 @@ $range = "[$version.0,$versionHigh.0)"
 $vs = Get-VSSetupInstance | Select-VSSetupInstance -Version $range -Product *
 
 if (!$vs) {
-  Write-Host 'Unable to get installed Visual Studio info'
+  Write-Error 'Unable to get installed Visual Studio info'
 
   exit 1
 }
@@ -14,7 +14,7 @@ if (!$vs) {
 $vsPath = $vs.InstallationPath
 
 if (!$vsPath) {
-  Write-Host 'Unable to get installed Visual Studio path'
+  Write-Error 'Unable to get installed Visual Studio path'
 
   exit 1
 }
@@ -22,7 +22,7 @@ if (!$vsPath) {
 $vcvars = Join-Path $vsPath 'VC/Auxiliary/Build/vcvarsall.bat'
 
 if (!(Test-Path $vcvars)) {
-  Write-Host 'Expected path for Visual Studio vsvarsall does not exist'
+  Write-Error 'Expected path for Visual Studio vsvarsall does not exist'
 
   exit 1
 }

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -1,25 +1,41 @@
 $version = $env:VS_VERSION
 $architecture = $env:VS_ARCH
-
-Write-Host 'Setup Visual C++ Build Environment ...'
-Write-Host "  Version: $version"
-Write-Host "  Architecture: $architecture"
-
+$debug = $env:DEBUG
 $versionHigh = $version + 1
 $range = "[$version.0,$versionHigh.0)"
 $vs = Get-VSSetupInstance | Select-VSSetupInstance -Version $range -Product *
 
 if (!$vs) {
+  Write-Host 'Unable to get installed Visual Studio info'
+
   exit 1
 }
 
 $vsPath = $vs.InstallationPath
 
 if (!$vsPath) {
+  Write-Host 'Unable to get installed Visual Studio path'
+
   exit 1
 }
 
 $vcvars = Join-Path $vsPath 'VC/Auxiliary/Build/vcvarsall.bat'
+
+if (!(Test-Path $vcvars)) {
+  Write-Host 'Expected path for Visual Studio vsvarsall does not exist'
+
+  exit 1
+}
+
+if ($debug -eq 1) {
+  Write-Host 'Setup Visual C++ Build Environment ...'
+  Write-Host "  Version: $version"
+  Write-Host "  Full Version: $($vs.InstallationVersion)"
+  Write-Host "  Architecture: $architecture"
+  Write-Host "  Name: $($vs.DisplayName)"
+  Write-Host "  Path: $vsPath"
+  Write-Host "  VCVars Path: $vcvars"
+}
 
 cmd /c """$vcvars"" $architecture & set" | foreach {
   if ($_ -Match "=") {
@@ -29,8 +45,11 @@ cmd /c """$vcvars"" $architecture & set" | foreach {
   }
 }
 
-Write-Host 'Done'
-Write-Host '------------------------------------------------------------'
+if ($debug -eq 1) {
+  Write-Host 'Done'
+  Write-Host '------------------------------------------------------------'
+}
+
 Invoke-Expression "$args"
 
 exit $LastExitCode


### PR DESCRIPTION
If you set `DEBUG=1` when running the docker container it will spit out a bunch of info about the setup of Visual Studio. Without this it will do the setup silently. Resolves #17.