### PR TITLE
Switch to Windows Server 2016

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # set input arguments to defaults
 ARG VS_VERSION


### PR DESCRIPTION
This is to try and resolve issues with builds and memory limit problems.