### PR TITLE
Update to latest windows server core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build (msvc-${{matrix.msvc}})
-    runs-on: windows-2022
+    runs-on: windows-latest
     strategy:
       matrix:
         msvc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build (msvc-${{matrix.msvc}})
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         msvc:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
 
 # set input arguments to defaults
 ARG VS_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 # set input arguments to defaults
 ARG VS_VERSION


### PR DESCRIPTION
This is needed since runners were updated to windows 2022. Windows docker requires that the host and guest operating systems are the same version for certain types of builds/containers. Builds will fail until this is merged.